### PR TITLE
Fix tool call argument serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 - Some context length might be taken up by internal instructions (but they dont seem to degrade the model) 
 - Use responsibly and at your own risk. This project is not affiliated with OpenAI, and is a educational exercise.
 
+### Tool Argument Shape
+
+- Tool arguments can be objects, arrays, or plain strings depending on what the model emits.
+- Serialization rules used across streaming and non‑streaming paths:
+  - Object (dict) or array (list) → serialized as‑is.
+  - String that parses to an object/array → parsed and used.
+  - Other strings → wrapped as `{ "query": "<string>" }`.
+- Arrays are preserved. If your tool schema expects a top‑level object, ensure your client handles both shapes or wraps arrays before consuming.
+
+Examples
+
+```
+"{\"city\":\"Paris\"}"   → {"city":"Paris"}
+"vector databases"        → {"query":"vector databases"}
+["a","b"]                 → ["a","b"]
+```
+
 # Supported models
 - `gpt-5`
 - `gpt-5-codex`

--- a/chatmock/routes_ollama.py
+++ b/chatmock/routes_ollama.py
@@ -12,7 +12,7 @@ from .http import build_cors_headers
 from .reasoning import build_reasoning_param, extract_reasoning_from_model_name
 from .transform import convert_ollama_messages, normalize_ollama_tools
 from .upstream import normalize_model_name, start_upstream_request
-from .utils import convert_chat_messages_to_responses_input, convert_tools_chat_to_responses
+from .utils import convert_chat_messages_to_responses_input, convert_tools_chat_to_responses, _serialize_tool_args
 
 
 ollama_bp = Blueprint("ollama", __name__)
@@ -445,8 +445,9 @@ def ollama_chat() -> Response:
                 if isinstance(item, dict) and item.get("type") == "function_call":
                     call_id = item.get("call_id") or item.get("id") or ""
                     name = item.get("name") or ""
-                    args = item.get("arguments") or ""
-                    if isinstance(call_id, str) and isinstance(name, str) and isinstance(args, str):
+                    raw_args = item.get("arguments") if item.get("arguments") is not None else item.get("parameters")
+                    if isinstance(call_id, str) and isinstance(name, str):
+                        args = _serialize_tool_args(raw_args)
                         tool_calls.append(
                             {
                                 "id": call_id,

--- a/chatmock/routes_openai.py
+++ b/chatmock/routes_openai.py
@@ -15,6 +15,7 @@ from .utils import (
     convert_tools_chat_to_responses,
     sse_translate_chat,
     sse_translate_text,
+    _serialize_tool_args,
 )
 
 
@@ -257,8 +258,9 @@ def chat_completions() -> Response:
                 if isinstance(item, dict) and item.get("type") == "function_call":
                     call_id = item.get("call_id") or item.get("id") or ""
                     name = item.get("name") or ""
-                    args = item.get("arguments") or ""
-                    if isinstance(call_id, str) and isinstance(name, str) and isinstance(args, str):
+                    raw_args = item.get("arguments") if item.get("arguments") is not None else item.get("parameters")
+                    if isinstance(call_id, str) and isinstance(name, str):
+                        args = _serialize_tool_args(raw_args)
                         tool_calls.append(
                             {
                                 "id": call_id,

--- a/chatmock/transform.py
+++ b/chatmock/transform.py
@@ -73,7 +73,7 @@ def convert_ollama_messages(
                         "type": "function",
                         "function": {
                             "name": name,
-                            "arguments": args if isinstance(args, str) else (json.dumps(args) if isinstance(args, dict) else "{}"),
+                            "arguments": args if isinstance(args, str) else (json.dumps(args) if isinstance(args, (dict, list)) else "{}"),
                         },
                     }
                 )

--- a/chatmock/utils.py
+++ b/chatmock/utils.py
@@ -9,6 +9,31 @@ import sys
 from typing import Any, Dict, List
 
 
+def _serialize_tool_args(eff_args: Any) -> str:
+    """
+    Serialize tool call arguments with proper JSON handling.
+
+    - dict/list -> JSON as-is
+    - string that parses to dict/list -> use parsed
+    - other strings -> {"query": <str>}
+    - anything else -> "{}"
+    """
+    if isinstance(eff_args, (dict, list)):
+        return json.dumps(eff_args)
+    if isinstance(eff_args, str):
+        s = eff_args
+        ch = s[:1]
+        if ch in ("{", "["):
+            try:
+                parsed = json.loads(s)
+                if isinstance(parsed, (dict, list)):
+                    return json.dumps(parsed)
+            except Exception:
+                pass
+        return json.dumps({"query": s})
+    return "{}"
+
+
 def eprint(*args, **kwargs) -> None:
     print(*args, file=sys.stderr, **kwargs)
 
@@ -254,30 +279,6 @@ def sse_translate_chat(
     ws_index: dict[str, int] = {}
     ws_next_index: int = 0
     
-    def _serialize_tool_args(eff_args: Any) -> str:
-        """
-        Serialize tool call arguments with proper JSON handling.
-        
-        Args:
-            eff_args: Arguments to serialize (dict, list, str, or other)
-            
-        Returns:
-            JSON string representation of the arguments
-        """
-        if isinstance(eff_args, (dict, list)):
-            return json.dumps(eff_args)
-        elif isinstance(eff_args, str):
-            try:
-                parsed = json.loads(eff_args)
-                if isinstance(parsed, (dict, list)):
-                    return json.dumps(parsed) 
-                else:
-                    return json.dumps({"query": eff_args})  
-            except (json.JSONDecodeError, ValueError):
-                return json.dumps({"query": eff_args})
-        else:
-            return "{}"
-    
     def _extract_usage(evt: Dict[str, Any]) -> Dict[str, int] | None:
         try:
             usage = (evt.get("response") or {}).get("usage")
@@ -321,12 +322,17 @@ def sse_translate_chat(
                             pass
                     item = evt.get('item') if isinstance(evt.get('item'), dict) else {}
                     params_dict = ws_state.setdefault(call_id, {}) if isinstance(ws_state.get(call_id), dict) else {}
+                    params_str: str | None = None
                     def _merge_from(src):
                         if not isinstance(src, dict):
                             return
                         for whole in ('parameters','args','arguments','input'):
-                            if isinstance(src.get(whole), dict):
-                                params_dict.update(src.get(whole))
+                            val = src.get(whole)
+                            if isinstance(val, dict):
+                                params_dict.update(val)
+                            elif isinstance(val, str) and val:
+                                nonlocal params_str
+                                params_str = val
                         if isinstance(src.get('query'), str): params_dict.setdefault('query', src.get('query'))
                         if isinstance(src.get('q'), str): params_dict.setdefault('query', src.get('q'))
                         for rk in ('recency','time_range','days'):
@@ -337,7 +343,7 @@ def sse_translate_chat(
                             if src.get(mk) is not None and 'max_results' not in params_dict: params_dict['max_results'] = src.get(mk)
                     _merge_from(item)
                     _merge_from(evt if isinstance(evt, dict) else None)
-                    params = params_dict if params_dict else None
+                    params = params_dict if params_dict else (params_str if isinstance(params_str, str) else None)
                     if isinstance(params, dict):
                         try:
                             ws_state.setdefault(call_id, {}).update(params)
@@ -345,44 +351,45 @@ def sse_translate_chat(
                             pass
                     eff_params = ws_state.get(call_id, params if isinstance(params, (dict, list, str)) else {})
                     args_str = _serialize_tool_args(eff_params)
-                    if call_id not in ws_index:
-                        ws_index[call_id] = ws_next_index
-                        ws_next_index += 1
-                    _idx = ws_index.get(call_id, 0)
-                    delta_chunk = {
-                        "id": response_id,
-                        "object": "chat.completion.chunk",
-                        "created": created,
-                        "model": model,
-                        "choices": [
-                            {
-                                "index": 0,
-                                "delta": {
-                                    "tool_calls": [
-                                        {
-                                            "index": _idx,
-                                            "id": call_id,
-                                            "type": "function",
-                                            "function": {"name": "web_search", "arguments": args_str},
-                                        }
-                                    ]
-                                },
-                                "finish_reason": None,
-                            }
-                        ],
-                    }
-                    yield f"data: {json.dumps(delta_chunk)}\n\n".encode("utf-8")
-                    if kind.endswith(".completed") or kind.endswith(".done"):
-                        finish_chunk = {
+                    if isinstance(call_id, str) and isinstance(args_str, str):
+                        if call_id not in ws_index:
+                            ws_index[call_id] = ws_next_index
+                            ws_next_index += 1
+                        _idx = ws_index.get(call_id, 0)
+                        delta_chunk = {
                             "id": response_id,
                             "object": "chat.completion.chunk",
                             "created": created,
                             "model": model,
                             "choices": [
-                                {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+                                {
+                                    "index": 0,
+                                    "delta": {
+                                        "tool_calls": [
+                                            {
+                                                "index": _idx,
+                                                "id": call_id,
+                                                "type": "function",
+                                                "function": {"name": "web_search", "arguments": args_str},
+                                            }
+                                        ]
+                                    },
+                                    "finish_reason": None,
+                                }
                             ],
                         }
-                        yield f"data: {json.dumps(finish_chunk)}\n\n".encode("utf-8")
+                        yield f"data: {json.dumps(delta_chunk)}\n\n".encode("utf-8")
+                        if kind.endswith(".completed") or kind.endswith(".done"):
+                            finish_chunk = {
+                                "id": response_id,
+                                "object": "chat.completion.chunk",
+                                "created": created,
+                                "model": model,
+                                "choices": [
+                                    {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+                                ],
+                            }
+                            yield f"data: {json.dumps(finish_chunk)}\n\n".encode("utf-8")
                 except Exception:
                     pass
 
@@ -429,11 +436,11 @@ def sse_translate_chat(
                             vlog(f"CM_TOOLS response.output_item.done web_search_call id={call_id} has_args={bool(args)}")
                         except Exception:
                             pass
-                    if call_id not in ws_index:
-                        ws_index[call_id] = ws_next_index
-                        ws_next_index += 1
-                    _idx = ws_index.get(call_id, 0)
                     if isinstance(call_id, str) and isinstance(name, str) and isinstance(args, str):
+                        if call_id not in ws_index:
+                            ws_index[call_id] = ws_next_index
+                            ws_next_index += 1
+                        _idx = ws_index.get(call_id, 0)
                         delta_chunk = {
                             "id": response_id,
                             "object": "chat.completion.chunk",


### PR DESCRIPTION
**What Changed**
- Reuse a single `_serialize_tool_args` in `utils`.
- Apply it to non‑stream routes (OpenAI, Ollama) so dict/list/string args serialize the same.
- Streaming web_search now preserves string `arguments`:
  - JSON string → parsed object
  - Plain string → {"query": "..."}
- `transform.py`: keep list arguments instead of turning them into `{}`.
- Guard `ws_index`: assign only when actually emitting a tool_call.

**Why**
- Non‑stream endpoints were skipping non‑string args.
- `response.web_search_call.arguments.delta` as a string became `{}` in streaming.
- Lists in assistant tool_calls were lost. This caused data loss and drift across code paths.

**How To Try Locally**
- Checkout PR #39, then this branch:
  - `gh pr checkout 39`  (RayBytes/ChatMock)
  - `git fetch alexx-ftw fix/tool-args && git switch fix/tool-args`
- Quick sanity (Python REPL):
```
from chatmock.utils import _serialize_tool_args
print(_serialize_tool_args('{"city":"Paris"}'))   # -> {"city":"Paris"}
print(_serialize_tool_args('vector databases'))     # -> {"query":"vector databases"}
print(_serialize_tool_args({"a":1,"b":2}))        # -> {"a":1,"b":2}
print(_serialize_tool_args([1,2,3]))                # -> [1,2,3]
```
- Minimal web_search delta check:
```
import json, time, os, sys
sys.path.insert(0, os.path.abspath('.'))
from typing import List
from chatmock.utils import sse_translate_chat
class FakeUpstream:
  def __init__(self,evts:List[dict]):
    self._l=[(f"data: {json.dumps(e)}\n\n").encode('utf-8') for e in evts]; self._l.append(b"data: [DONE]\n\n")
  def iter_lines(self,decode_unicode=False):
    for ln in self._l: yield ln
  def close(self): pass
def collect(g):
  out=[]
  for raw in g:
    s=raw.decode('utf-8') if isinstance(raw,(bytes,bytearray)) else raw
    if not s.startswith('data: '): continue
    d=s[len('data: '):].strip()
    if not d or d=='[DONE]': continue
    o=json.loads(d)
    for ch in o.get('choices') or []:
      dlt=ch.get('delta') or {}
      if 'tool_calls' in dlt: out.extend(dlt['tool_calls'])
  return out
# JSON string
evt={"type":"response.web_search_call.arguments.delta","item_id":"ws_1","arguments":json.dumps({"query":"red fox","max_results":2})}
print(collect(sse_translate_chat(FakeUpstream([evt]),'gpt-5',int(time.time())))[-1]['function']['arguments'])
# Plain string
evt={"type":"response.web_search_call.arguments.delta","item_id":"ws_2","arguments":"otters habitat"}
print(collect(sse_translate_chat(FakeUpstream([evt]),'gpt-5',int(time.time())))[-1]['function']['arguments'])
```

**Flags**
- None added or removed.

**Safety Limits**
- Objects/arrays pass through as structured JSON; plain strings become {"query": str}.
- Non‑serializable values fall back to "{}".

**Fallback Behavior**
- Matches prior defensive defaults outside tool argument handling.
